### PR TITLE
Replace json crate and make json an optional feature

### DIFF
--- a/jfifdump-cli/Cargo.toml
+++ b/jfifdump-cli/Cargo.toml
@@ -17,4 +17,4 @@ doc = false
 
 [dependencies]
 clap = { version = "4.3", features = ["cargo"] }
-jfifdump = { path = "../jfifdump", version = "0.4.0" }
+jfifdump = { path = "../jfifdump", version = "0.4.0", features = ["json"] }

--- a/jfifdump/Cargo.toml
+++ b/jfifdump/Cargo.toml
@@ -10,5 +10,9 @@ keywords = ["jpg", "jpeg", "image"]
 readme = "../README.md"
 repository = "https://github.com/vstroebel/jfifdump.git"
 
+[features]
+default = []
+json = ["jzon"]
+
 [dependencies]
-jzon = "0.12"
+jzon = { version = "0.12", optional = true }

--- a/jfifdump/Cargo.toml
+++ b/jfifdump/Cargo.toml
@@ -11,4 +11,4 @@ readme = "../README.md"
 repository = "https://github.com/vstroebel/jfifdump.git"
 
 [dependencies]
-json = "0.12"
+jzon = "0.12"

--- a/jfifdump/src/json.rs
+++ b/jfifdump/src/json.rs
@@ -1,8 +1,22 @@
 use crate::{App0Jfif, Dac, Dht, Dqt, Frame, Handler, Rst, Scan};
 
-use crate::reader::get_marker_string;
+use std::fmt::Write;
 use jzon::object::Object;
 use jzon::{object, JsonValue};
+
+pub fn get_marker_string(data: &[u8], max: usize) -> String {
+    let mut result = "".to_owned();
+    for &v in data.iter().take(max) {
+        if v.is_ascii_graphic() || v == 0x20 {
+            result.push(v as char);
+        } else {
+            write!(result, "\\x{:#04X}", v).unwrap();
+        }
+    }
+
+    result
+}
+
 
 pub struct JsonFormat {
     markers: Vec<JsonValue>,

--- a/jfifdump/src/json.rs
+++ b/jfifdump/src/json.rs
@@ -1,8 +1,8 @@
 use crate::{App0Jfif, Dac, Dht, Dqt, Frame, Handler, Rst, Scan};
 
 use crate::reader::get_marker_string;
-use json::object::Object;
-use json::{object, JsonValue};
+use jzon::object::Object;
+use jzon::{object, JsonValue};
 
 pub struct JsonFormat {
     markers: Vec<JsonValue>,
@@ -22,7 +22,7 @@ impl JsonFormat {
     }
 
     pub fn stringify(&self) -> String {
-        json::stringify_pretty(JsonValue::Array(self.markers.clone()), 4)
+        jzon::stringify_pretty(JsonValue::Array(self.markers.clone()), 4)
     }
 }
 

--- a/jfifdump/src/lib.rs
+++ b/jfifdump/src/lib.rs
@@ -45,10 +45,12 @@ pub use reader::{
 };
 pub use text::TextFormat;
 
+#[cfg(feature = "json")]
 pub use crate::json::JsonFormat;
 
 mod error;
 mod handler;
+#[cfg(feature = "json")]
 mod json;
 mod reader;
 mod text;

--- a/jfifdump/src/reader.rs
+++ b/jfifdump/src/reader.rs
@@ -1,4 +1,3 @@
-use std::fmt::Write;
 use std::io::{Error as IoError, Read};
 
 pub use crate::JfifError;
@@ -463,17 +462,4 @@ impl Frame {
             _ => "Unknown",
         }
     }
-}
-
-pub fn get_marker_string(data: &[u8], max: usize) -> String {
-    let mut result = "".to_owned();
-    for &v in data.iter().take(max) {
-        if v.is_ascii_graphic() || v == 0x20 {
-            result.push(v as char);
-        } else {
-            write!(result, "\\x{:#04X}", v).unwrap();
-        }
-    }
-
-    result
 }


### PR DESCRIPTION
As mentioned in #4  the json crate is unmaintained. 

Replace it with jzon as a simple drop in replacement and make it an optional feature.

fixes #4 
